### PR TITLE
Use `shiftfs` for mounting shared directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ Install with: `$ sudo apt install jq`
 - Copy the example `/.lexi` directory into any project and edit the YAML files to taste
 - Run `$ lexi setup` to create the network bridge used by `lexi`. This should only be needed once.
 
+##### Shared directories
+
+Lexi uses `shiftfs` for managing user mappings on directories shared between the host and the container.
+
+This requires a recent Linux kernel on the host (5+) which is present in Ubuntu 18 and above.
+
+To check if you have `shiftfs` enabled, do: `$ modinfo shiftfs`.
+
+To enable `shiftfs` with LXD (snap version), do:
+```
+$ sudo snap set lxd shiftfs.enable=true
+$ sudo systemctl reload snap.lxd.daemon
+```
+
+For more info on `shiftfs` see [this post](https://discuss.linuxcontainers.org/t/trying-out-shiftfs/5155).
+
 ## Config Files
 
 See [local config README](.lexi/README.md)

--- a/lexi
+++ b/lexi
@@ -28,47 +28,20 @@ function check_running {
   fi
 }
 
-function setup_uid_map {
-  echo "Lexi: configuring uid maps"
-
-  if grep -Fq "lxd:" /etc/subuid; then
-    echo "Lexi: subuid mapping for 'lxd:' already exists... ignoring"
-  else
-    echo "lxd:$(id -u):1" | sudo tee -a /etc/subuid 2>&1
-  fi
-
-  if grep -Fq "root:" /etc/subuid; then
-    echo "Lexi: subuid mapping for 'root:' already exists... ignoring"
-  else
-    echo "root:$(id -u):1" | sudo tee -a /etc/subuid 2>&1
-  fi
-
-  echo "Lexi: configuring gid maps"
-
-  if grep -Fq "lxd:" /etc/subgid; then
-    echo "Lexi: subgid mapping for 'lxd:' already exists... ignoring"
-  else
-    printf "lxd:$(id -g):1\n" | sudo tee -a /etc/subgid 2>&1
-  fi
-
-  if grep -Fq "root:" /etc/subgid; then
-    echo "Lexi: subgid mapping for 'root:' already exists... ignoring"
-  else
-    printf "root:$(id -g):1\n" | sudo tee -a /etc/subgid 2>&1
-  fi
-}
-
-function apply_uid_mapping {
-  if [ -n "$host_share_path" ] && [ -n "$guest_share_path" ]; then
-    echo "Lexi: applying uid mappings for shared directory"
-    printf "uid $(id -u) 1000\ngid $(id -g) 1000" | lxc config set $container raw.idmap -
+function check_shiftfs_suport {
+  modinfo shiftfs &> /dev/null
+  if [ 0 != $? ]; then
+    echo "Lexi: shiftfs support not enabled. Shared mounts will be read-only in containers. For setup details, see:"
+    echo "https://discuss.linuxcontainers.org/t/trying-out-shiftfs/5155/9"
   fi
 }
 
 function mount_shared_directory {
+  check_shiftfs_suport
+
   if [ -n "$host_share_path" ] && [ -n "$guest_share_path" ]; then
     echo "Lexi: adding shared directory: (host) $host_share_path -> (guest) $guest_share_path"
-    lxc config device add $container ${container}-share disk source=$host_share_path path=$guest_share_path
+    lxc config device add $container ${container}-share disk source=$host_share_path path=$guest_share_path shift=true
   fi
 }
 
@@ -86,7 +59,6 @@ function lexi_launch {
   lxc network attach $network_name $container eth0
   echo "Lexi: configuring network interface with IP: $container_ip"
   lxc config device set $container eth0 ipv4.address $container_ip
-  apply_uid_mapping
   mount_shared_directory
   lxc start $container
 }
@@ -135,11 +107,8 @@ case $command in
   "setup")
     echo "Lexi: creating network '$network_name'"
     lxc network create $network_name ipv6.address=none ipv4.address=${network_address}/24 ipv4.nat=true
-    setup_uid_map
-    echo
-    echo "Setup complete. Restart LXD to apply user mapping configuration."
-    echo "Snap version: 'systemctl reload snap.lxd.daemon'"
-    echo "Non-Snap version: 'sudo systemctl restart lxd'"
+
+    check_shiftfs_suport
     ;;
   "launch")
     check_exists


### PR DESCRIPTION
Switches to using `shiftfs` for managing user mappings on shared directories.